### PR TITLE
fix(cookiecutter): add the missing option `add_payments_module`

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,6 @@
     "version": "0.0.0",
     "_copy_without_render": [
         "*.tpl"
-    ]
+    ],
+    "add_payments_module": "n"
 }


### PR DESCRIPTION
> Why was this change necessary?

To fix the Cookiecutter template, as described in issue #38 

> How does it address the problem?

It adds the missing Cookiecutter option `add_payments_module`

> Are there any side effects?

An additional option shows up while bootstraping the template.
Note that the behaviour of setting `add_payments_module` set to `y` was not checked nor tested.

Resolve #38 